### PR TITLE
Improve forum search result details

### DIFF
--- a/src/main/java/org/scijava/search/web/ImageJForumSearcher.java
+++ b/src/main/java/org/scijava/search/web/ImageJForumSearcher.java
@@ -92,16 +92,12 @@ public class ImageJForumSearcher implements Searcher {
 				final String forumPostUrl = "http://forum.imagej.net/t/" + metaInfo.get(
 					"slug") + "/" + metaInfo.get("id") + "/";
 
-				final String details = "Tags: " + metaInfo.get("tags") + "<br />" +
-					"Created: " + metaInfo.get("created_at") + "<br />" +
-					"Last posted: " + metaInfo.get("last_posted_at");
-
 				final Map<String, String> extraProps = new LinkedHashMap<>();
 				extraProps.put("Tags", metaInfo.get("tags"));
 				extraProps.put("Created", formatDate(metaInfo.get("created_at")));
 				extraProps.put("Last posted", formatDate(metaInfo.get("last_posted_at")));
 				searchResults.add(new WebSearchResult(metaInfo.get("title"), //
-					forumPostUrl, details, null, extraProps));
+					forumPostUrl, "", null, extraProps));
 			}
 		}
 		catch (final IOException e) {


### PR DESCRIPTION
This is a minimal change removing duplicate information in the details section of a forum search result.

Maybe `details` could be used to show an excerpt of the page as we do for Wiki searches, but I think the current amount of information is sufficient as well.