### PR TITLE
ModuleSearchResult: be more defensive when checking menu leaf

### DIFF
--- a/src/main/java/org/scijava/search/module/ModuleSearchResult.java
+++ b/src/main/java/org/scijava/search/module/ModuleSearchResult.java
@@ -83,7 +83,7 @@ public class ModuleSearchResult implements SearchResult {
 
 	@Override
 	public String context() {
-		return "/" + getMenuPath(name() != info.getMenuPath().getLeaf().toString(), "/");
+		return "/" + getMenuPath(name() != "" + info.getMenuPath().getLeaf(), "/");
 	}
 
 	@Override


### PR DESCRIPTION
When `info.getMenuPath().getLeaf()` was `null`, the `context()` method was throwing a `NullPointerException`. This is the case for e.g. `net.imagej.updater.PromptUserToUpdate` - just search for the label *There are updates available*.

Let's be more defensive and avoid calling the `toString()` method on `MenuEntry`.

Alternatively, instead of:
`name() != "" + info.getMenuPath().getLeaf()`
we could also use:
`name() != Objects.toString(info.getMenuPath().getLeaf())`
(see [this SO post](https://stackoverflow.com/q/5522201/1919049)).

Any opinions, @frauzufall ?
