### PR TITLE
Improve module search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,5 +118,10 @@
 			<artifactId>prettytime</artifactId>
 			<version>${prettytime.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/scijava/search/module/ModuleSearcher.java
+++ b/src/main/java/org/scijava/search/module/ModuleSearcher.java
@@ -29,6 +29,7 @@
 
 package org.scijava.search.module;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -80,21 +81,32 @@ public class ModuleSearcher implements Searcher {
 			.collect(Collectors.toList());
 
 		final String textLower = text.toLowerCase();
+		final List<String> textLowerParts = Arrays.asList(textLower.split("\\s+"));
 
-		// First, add modules where title starts with the text.
+		// Add modules where title starts with the text.
 		modules.stream() //
 			.filter(info -> startsWith(info, textLower) ) //
 			.forEach(matches::add);
 
-		// Next, add modules where title has text inside somewhere.
+		// Add modules where title has text inside somewhere.
 		modules.stream() //
 			.filter(info -> hasSubstringInTitle(info, textLower)) //
 			.forEach(matches::add);
 
-		// Finally, add modules where menu path has text inside somewhere.
+		// Add modules where menu path has text inside somewhere.
 		modules.stream() //
 			.filter(info -> hasSubstringInMenu(info, textLower)) //
 			.forEach(matches::add);
+
+		// Add modules where title has all parts of the text inside somewhere.
+		modules.stream() //
+				.filter(info -> hasSubstringsInTitle(info, textLowerParts)) //
+				.forEach(matches::add);
+
+		// Add modules where menu path has all parts of the text inside somewhere.
+		modules.stream() //
+				.filter(info -> hasSubstringsInMenu(info, textLowerParts)) //
+				.forEach(matches::add);
 
 		// Wrap each matching ModuleInfo in a ModuleSearchResult.
 		return matches.stream() //
@@ -168,11 +180,27 @@ public class ModuleSearcher implements Searcher {
 			title.toLowerCase().matches(".*" + desiredLower + ".*");
 	}
 
+	private boolean hasSubstringsInTitle(final ModuleInfo info,
+	                                    final List<String> desiredLower)
+	{
+		final String title = title(info);
+		if(title == null) return false;
+		return desiredLower.stream().allMatch(part -> title.toLowerCase().contains(part));
+	}
+
 	private boolean hasSubstringInMenu(final ModuleInfo info,
 	                                    final String desiredLower)
 	{
 		MenuPath menuPath = info.getMenuPath();
 		if(menuPath == null) return false;
 		return menuPath.stream().anyMatch(entry -> entry.getName().toLowerCase().contains(desiredLower));
+	}
+
+	private boolean hasSubstringsInMenu(final ModuleInfo info,
+	                                    final List<String> desiredLower)
+	{
+		MenuPath menuPath = info.getMenuPath();
+		if(menuPath == null) return false;
+		return desiredLower.stream().allMatch(part -> menuPath.stream().anyMatch(entry -> entry.getName().toLowerCase().contains(part)));
 	}
 }

--- a/src/main/java/org/scijava/search/module/ModuleSearcher.java
+++ b/src/main/java/org/scijava/search/module/ModuleSearcher.java
@@ -88,12 +88,12 @@ public class ModuleSearcher implements Searcher {
 
 		// Next, add modules where title has text inside somewhere.
 		modules.stream() //
-			.filter(info -> hasSubstring(info, textLower)) //
+			.filter(info -> hasSubstringInTitle(info, textLower)) //
 			.forEach(matches::add);
 
 		// Finally, add modules where menu path has text inside somewhere.
 		modules.stream() //
-			.filter(info -> hasSubstring(info, textLower)) //
+			.filter(info -> hasSubstringInMenu(info, textLower)) //
 			.forEach(matches::add);
 
 		// Wrap each matching ModuleInfo in a ModuleSearchResult.
@@ -160,11 +160,19 @@ public class ModuleSearcher implements Searcher {
 		return title != null && title.toLowerCase().startsWith(desiredLower);
 	}
 
-	private boolean hasSubstring(final ModuleInfo info,
-		final String desiredLower)
+	private boolean hasSubstringInTitle(final ModuleInfo info,
+	                                    final String desiredLower)
 	{
 		final String title = title(info);
 		return title != null && //
 			title.toLowerCase().matches(".*" + desiredLower + ".*");
+	}
+
+	private boolean hasSubstringInMenu(final ModuleInfo info,
+	                                    final String desiredLower)
+	{
+		MenuPath menuPath = info.getMenuPath();
+		if(menuPath == null) return false;
+		return menuPath.stream().anyMatch(entry -> entry.getName().toLowerCase().contains(desiredLower));
 	}
 }

--- a/src/test/java/org/scijava/search/module/ModuleSearcherTest.java
+++ b/src/test/java/org/scijava/search/module/ModuleSearcherTest.java
@@ -1,0 +1,95 @@
+package org.scijava.search.module;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.InstantiableException;
+import org.scijava.MenuPath;
+import org.scijava.command.CommandInfo;
+import org.scijava.module.ModuleInfo;
+import org.scijava.module.ModuleService;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
+import org.scijava.search.SearchResult;
+import org.scijava.search.Searcher;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ModuleSearcherTest {
+
+	private ModuleService moduleService;
+	private Searcher moduleSearcher;
+
+	@Before
+	public void init() throws InstantiableException {
+		Context context = new Context();
+		moduleService = context.getService(ModuleService.class);
+		PluginInfo<Searcher> info = context.getService(PluginService.class).getPlugin(ModuleSearcher.class, Searcher.class);
+		moduleSearcher = info.createInstance();
+		context.inject(moduleSearcher);
+	}
+
+	@Test
+	public void testMatchingBeginning() {
+		createTestModule("Do something silly", "");
+		List<SearchResult> results = moduleSearcher.search("Do", true);
+		assertNotNull(results);
+		assertTrue(results.size()>=1);
+		assertTrue(containsModule(results, "Do something silly"));
+	}
+
+	@Test
+	public void testMatchingParts() {
+		createTestModule("Do something silly", "");
+		List<SearchResult> results = moduleSearcher.search("Do silly", true);
+		assertNotNull(results);
+		assertTrue(results.size()>=1);
+		assertTrue(containsModule(results, "Do something silly"));
+	}
+
+	@Test
+	public void testMatchingEnd() {
+		createTestModule("Do something silly", "");
+		List<SearchResult> results = moduleSearcher.search("silly", true);
+		assertNotNull(results);
+		assertTrue(results.size()>=1);
+		assertTrue(containsModule(results, "Do something silly"));
+	}
+
+	@Test
+	public void testCaseMismatch() {
+		createTestModule("Do something silly", "");
+		List<SearchResult> results = moduleSearcher.search("do", true);
+		assertNotNull(results);
+		assertTrue(results.size()>=1);
+		assertTrue(containsModule(results, "Do something silly"));
+	}
+
+	@Test
+	public void testMenu() {
+		createTestModule("nolabel", "Do>something>silly");
+		List<SearchResult> results = moduleSearcher.search("silly", true);
+		assertNotNull(results);
+		assertTrue(results.size()>=1);
+		assertTrue(containsModule(results, "nolabel"));
+	}
+
+	private boolean containsModule(List<SearchResult> results, String moduleName) {
+		boolean foundModule = false;
+		for(SearchResult result : results) {
+			if(moduleName.equals(result.identifier())) foundModule = true;
+		}
+		return foundModule;
+	}
+
+	private void createTestModule(String label, String menuPath) {
+		ModuleInfo info = new CommandInfo(TestCommand.class);
+		info.setLabel(label);
+		info.setMenuPath(new MenuPath(menuPath));
+		moduleService.addModule(info);
+	}
+
+}

--- a/src/test/java/org/scijava/search/module/ModuleSearcherTest.java
+++ b/src/test/java/org/scijava/search/module/ModuleSearcherTest.java
@@ -15,6 +15,7 @@ import org.scijava.search.Searcher;
 
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -75,6 +76,23 @@ public class ModuleSearcherTest {
 		assertNotNull(results);
 		assertTrue(results.size()>=1);
 		assertTrue(containsModule(results, "nolabel"));
+	}
+
+	@Test
+	public void testMatchingPartsInMenu() {
+		createTestModule("nolabel", "Do>something>silly");
+		List<SearchResult> results = moduleSearcher.search("Do silly", true);
+		assertNotNull(results);
+		assertTrue(results.size()>=1);
+		assertTrue(containsModule(results, "nolabel"));
+	}
+
+	@Test
+	public void testNonMatchingPartsInMenu() {
+		createTestModule("nolabel", "Do>something>silly");
+		List<SearchResult> results = moduleSearcher.search("Do nothing", true);
+		assertNotNull(results);
+		assertFalse(containsModule(results, "nolabel"));
 	}
 
 	private boolean containsModule(List<SearchResult> results, String moduleName) {

--- a/src/test/java/org/scijava/search/module/TestCommand.java
+++ b/src/test/java/org/scijava/search/module/TestCommand.java
@@ -1,0 +1,10 @@
+package org.scijava.search.module;
+
+import org.scijava.command.Command;
+
+public class TestCommand implements Command {
+	@Override
+	public void run() {
+
+	}
+}


### PR DESCRIPTION
This PR adds the following search features to ModuleSearcher:
- searching the menu
- searching for parts of the search string divided by space individually

It also adds a bunch of tests for the ModuleSearcher.

Ideally we would use a fuzzy logic algorithm. I would like to integrate [fuzzywuzzy](https://github.com/xdrop/fuzzywuzzy), but it's GPLv3 licensed which might be an issue?