### PR TITLE
Upgrade to miglayout-swing-5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 
@@ -91,6 +91,7 @@
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<prettytime.version>4.0.1.Final</prettytime.version>
+		<miglayout-swing.version>5.2</miglayout-swing.version>
 	</properties>
 
 	<repositories>
@@ -110,8 +111,8 @@
 		<!-- Third-party dependencies -->
 		<dependency>
 			<groupId>com.miglayout</groupId>
-			<artifactId>miglayout</artifactId>
-			<classifier>swing</classifier>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ocpsoft.prettytime</groupId>


### PR DESCRIPTION
The version pinning can be removed once we have a `pom-scijava` release managing this version (see scijava/pom-scijava#97).