### PR TITLE
deactivating searches which are not functional anyway

### DIFF
--- a/src/main/java/org/scijava/search/web/ImageForumSearcher.java
+++ b/src/main/java/org/scijava/search/web/ImageForumSearcher.java
@@ -53,7 +53,7 @@ import org.scijava.search.Searcher;
  *
  * @author Robert Haase (MPI-CBG)
  */
-@Plugin(type = Searcher.class, enabled = false)
+//@Plugin(type = Searcher.class, enabled = false)
 public class ImageForumSearcher implements Searcher {
 
 	@Parameter

--- a/src/main/java/org/scijava/search/web/ImageJWikiSearcher.java
+++ b/src/main/java/org/scijava/search/web/ImageJWikiSearcher.java
@@ -56,7 +56,7 @@ import org.xml.sax.SAXException;
  *
  * @author Robert Haase (MPI-CBG)
  */
-@Plugin(type = Searcher.class, priority = Priority.HIGH, enabled = false)
+//@Plugin(type = Searcher.class, priority = Priority.HIGH, enabled = false)
 public class ImageJWikiSearcher implements Searcher {
 
 	private final ArrayList<SearchResult> searchResults = new ArrayList<>();


### PR DESCRIPTION
Hey Curtis @ctrueden ,

I'm suggesting to deactivate searches for the forum and for the wiki. These are not functional at the moment anyway:
![image](https://user-images.githubusercontent.com/12660498/93661804-1afd5780-fa5b-11ea-8399-d0848c805cbe.png)

We can reactivate them as soon as the searches have been adapted to the new websites.

Thanks!

Cheers,
Robert
