### PR TITLE
Respect non-standard build source directories in SourceFinder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
 			<properties><id>haesleinhuepf</id></properties>
 			<roles><role>founder</role></roles>
 		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>https://imagej.net/people/imagejan</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>
@@ -91,6 +96,9 @@
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
 		<prettytime.version>4.0.1.Final</prettytime.version>
+
+		<!-- NB: Pin imagej1 version for test -->
+		<imagej1.version>1.53q</imagej1.version>
 	</properties>
 
 	<repositories>
@@ -120,6 +128,13 @@
 			<groupId>org.ocpsoft.prettytime</groupId>
 			<artifactId>prettytime</artifactId>
 			<version>${prettytime.version}</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/scijava/search/SourceFinder.java
+++ b/src/main/java/org/scijava/search/SourceFinder.java
@@ -96,7 +96,8 @@ public final class SourceFinder {
 			if (!scmURL.endsWith("/")) url.append("/");
 			url.append("blob/");
 			url.append(tag);
-			url.append("/src/main/java/");
+			final String sourceDir = pom.cdata("//build/sourceDirectory");
+			url.append(sourceDir == null ? "/src/main/java/" : sourceDir.replace("${project.basedir}", "") + "/");
 			url.append(c.getName().replaceAll("\\.", "/"));
 			url.append(".java");
 			return new URL(url.toString());

--- a/src/main/java/org/scijava/search/SourceFinder.java
+++ b/src/main/java/org/scijava/search/SourceFinder.java
@@ -29,20 +29,12 @@
 
 package org.scijava.search;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.scijava.log.Logger;
-import org.scijava.util.AppUtils;
-import org.scijava.util.FileUtils;
 import org.scijava.util.Manifest;
 import org.scijava.util.POM;
-import org.scijava.util.Types;
-import org.xml.sax.SAXException;
 
 /**
  * Static utility class for finding source URL of a given class.
@@ -63,7 +55,7 @@ public final class SourceFinder {
 		throws SourceNotFoundException
 	{
 		try {
-			final POM pom = getPOM(c, null, null);
+			final POM pom = POM.getPOM(c);
 			if (pom == null) {
 				log.debug("No Maven POM found for class: " + c.getName());
 				throw new SourceNotFoundException(c, null);
@@ -124,51 +116,4 @@ public final class SourceFinder {
 		return g + ":" + a + ":" + v;
 	}
 
-	// TODO: Use org.scijava.util.POM.getPOM from scijava-common 2.77.0.
-
-	/**
-	 * Gets the Maven POM associated with the given class.
-	 * 
-	 * @param c The class to use as a base when searching for a pom.xml.
-	 * @param groupId The Maven groupId of the desired POM.
-	 * @param artifactId The Maven artifactId of the desired POM.
-	 */
-	private static POM getPOM(final Class<?> c, final String groupId,
-		final String artifactId)
-	{
-		try {
-			final URL location = Types.location(c);
-			if (!location.getProtocol().equals("file") ||
-				location.toString().endsWith(".jar"))
-			{
-				// look for pom.xml in JAR's META-INF/maven subdirectory
-				if (groupId == null || artifactId == null) {
-					// groupId and/or artifactId is unknown; scan for the POM
-					final URL pomBase = new URL("jar:" + //
-						location.toString() + "!/META-INF/maven");
-					for (final URL url : FileUtils.listContents(pomBase, true, true)) {
-						if (url.toExternalForm().endsWith("/pom.xml")) {
-							return new POM(url);
-						}
-					}
-				}
-				else {
-					// known groupId and artifactId; grab it directly
-					final String pomPath =
-						"META-INF/maven/" + groupId + "/" + artifactId + "/pom.xml";
-					final URL pomURL =
-						new URL("jar:" + location.toString() + "!/" + pomPath);
-					return new POM(pomURL);
-				}
-			}
-			// look for the POM in the class's base directory
-			final File file = FileUtils.urlToFile(location);
-			final File baseDir = AppUtils.getBaseDirectory(file, null);
-			final File pomFile = new File(baseDir, "pom.xml");
-			return new POM(pomFile);
-		}
-		catch (final IOException | ParserConfigurationException | SAXException e) {
-			return null;
-		}
-	}
 }

--- a/src/test/java/org/scijava/search/SourceFinderTest.java
+++ b/src/test/java/org/scijava/search/SourceFinderTest.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * Search framework for SciJava applications.
+ * %%
+ * Copyright (C) 2017 - 2022 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.scijava.search;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.log.LogService;
+
+import ij.IJ;
+
+public class SourceFinderTest {
+
+	private Context context;
+	private LogService logService;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		logService = context.service(LogService.class);
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	@Test
+	public void testSourceLocation() throws SourceNotFoundException {
+		URL url = SourceFinder.sourceLocation(IJ.class, logService);
+		// NB: we expect the version as pinned in pom.xml
+		String expected = "/imagej/ImageJ/blob/v1.53q/ij/IJ.java";
+		assertEquals(expected, url.getPath());
+	}
+}


### PR DESCRIPTION
Some projects define a `<sourceDirectory>` in their POM. Let's respect this when building our source location URL.
This pull request also adds a test for the `net.imagej:ij` artifact pinned at version `1.53q` and adds this as a test dependency.

Closes #22.