### PR TITLE
Port imagej legacy search actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.classpath
 /.project
 /.settings/
+
+# IntelliJ #
+/.idea/

--- a/src/main/java/org/scijava/search/SourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/SourceSearchActionFactory.java
@@ -1,0 +1,59 @@
+
+package org.scijava.search;
+
+import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
+import org.scijava.plugin.Parameter;
+import org.scijava.search.DefaultSearchAction;
+import org.scijava.search.SearchAction;
+import org.scijava.search.SearchActionFactory;
+import org.scijava.search.SearchResult;
+import org.scijava.search.SourceFinder;
+import org.scijava.search.SourceNotFoundException;
+import org.scijava.ui.UIService;
+
+import java.io.IOException;
+import java.net.URL;
+
+public abstract class SourceSearchActionFactory implements SearchActionFactory {
+
+	@Parameter
+	private LogService log;
+
+	@Parameter
+	private UIService uiService;
+
+	@Parameter
+	private PlatformService platformService;
+
+	public abstract Class<?> classFromSearchResult(final SearchResult result);
+
+	@Override
+	public SearchAction create(final SearchResult result) {
+		return new DefaultSearchAction("Source", //
+			() -> source(classFromSearchResult(result)));
+	}
+
+	private void source(final Class<?> c) {
+		URL sourceLocation = null;
+		try {
+			sourceLocation = SourceFinder.sourceLocation(c, log);
+		}
+		catch (final SourceNotFoundException exc) {
+			log.error(exc);
+		}
+		if (sourceLocation == null) {
+			uiService.showDialog("Source location unknown for " + c.getName());
+			return;
+		}
+		try {
+			platformService.open(sourceLocation);
+		}
+		catch (final IOException exc) {
+			log.error(exc);
+			uiService.showDialog("Platform error opening source URL: " +
+				sourceLocation);
+		}
+	}
+
+}

--- a/src/main/java/org/scijava/search/SourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/SourceSearchActionFactory.java
@@ -54,7 +54,7 @@ public abstract class SourceSearchActionFactory implements SearchActionFactory {
 	@Parameter
 	private PlatformService platformService;
 
-	public abstract Class<?> classFromSearchResult(final SearchResult result);
+	protected abstract Class<?> classFromSearchResult(final SearchResult result);
 
 	@Override
 	public SearchAction create(final SearchResult result) {

--- a/src/main/java/org/scijava/search/SourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/SourceSearchActionFactory.java
@@ -43,6 +43,11 @@ import org.scijava.ui.UIService;
 import java.io.IOException;
 import java.net.URL;
 
+/**
+ * Search action for viewing the source code of a SciJava module.
+ *
+ * @author Curtis Rueden
+ */
 public abstract class SourceSearchActionFactory implements SearchActionFactory {
 
 	@Parameter

--- a/src/main/java/org/scijava/search/SourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/SourceSearchActionFactory.java
@@ -1,3 +1,31 @@
+/*
+ * #%L
+ * Search framework for SciJava applications.
+ * %%
+ * Copyright (C) 2017 - 2021 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 
 package org.scijava.search;
 

--- a/src/main/java/org/scijava/search/SourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/SourceSearchActionFactory.java
@@ -29,19 +29,14 @@
 
 package org.scijava.search;
 
+import java.io.IOException;
+import java.net.URL;
+
 import org.scijava.log.LogService;
 import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
-import org.scijava.search.DefaultSearchAction;
-import org.scijava.search.SearchAction;
-import org.scijava.search.SearchActionFactory;
-import org.scijava.search.SearchResult;
-import org.scijava.search.SourceFinder;
-import org.scijava.search.SourceNotFoundException;
 import org.scijava.ui.UIService;
 
-import java.io.IOException;
-import java.net.URL;
 
 /**
  * Search action for viewing the source code of a SciJava module.

--- a/src/main/java/org/scijava/search/classes/ClassSourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/classes/ClassSourceSearchActionFactory.java
@@ -48,7 +48,7 @@ public class ClassSourceSearchActionFactory extends SourceSearchActionFactory {
 	}
 
 	@Override
-	public Class<?> classFromSearchResult(SearchResult result) {
+	protected Class<?> classFromSearchResult(SearchResult result) {
 		return ((ClassSearchResult) result).clazz();
 	}
 }

--- a/src/main/java/org/scijava/search/classes/ClassSourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/classes/ClassSourceSearchActionFactory.java
@@ -29,20 +29,10 @@
 
 package org.scijava.search.classes;
 
-import java.io.IOException;
-import java.net.URL;
-
-import org.scijava.log.LogService;
-import org.scijava.platform.PlatformService;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.search.DefaultSearchAction;
-import org.scijava.search.SearchAction;
 import org.scijava.search.SearchActionFactory;
 import org.scijava.search.SearchResult;
-import org.scijava.search.SourceFinder;
-import org.scijava.search.SourceNotFoundException;
-import org.scijava.ui.UIService;
+import org.scijava.search.SourceSearchActionFactory;
 
 /**
  * Search action for viewing the source code of a Java class.
@@ -50,16 +40,7 @@ import org.scijava.ui.UIService;
  * @author Curtis Rueden
  */
 @Plugin(type = SearchActionFactory.class)
-public class SourceSearchActionFactory implements SearchActionFactory {
-
-	@Parameter
-	private LogService log;
-
-	@Parameter
-	private UIService uiService;
-
-	@Parameter
-	private PlatformService platformService;
+public class ClassSourceSearchActionFactory extends SourceSearchActionFactory {
 
 	@Override
 	public boolean supports(final SearchResult result) {
@@ -67,30 +48,7 @@ public class SourceSearchActionFactory implements SearchActionFactory {
 	}
 
 	@Override
-	public SearchAction create(final SearchResult result) {
-		return new DefaultSearchAction("Source", //
-			() -> source(((ClassSearchResult) result).clazz()));
-	}
-
-	private void source(final Class<?> c) {
-		URL sourceLocation = null;
-		try {
-			sourceLocation = SourceFinder.sourceLocation(c, log);
-		}
-		catch (final SourceNotFoundException exc) {
-			log.error(exc);
-		}
-		if (sourceLocation == null) {
-			uiService.showDialog("Source location unknown for " + c.getName());
-			return;
-		}
-		try {
-			platformService.open(sourceLocation);
-		}
-		catch (final IOException exc) {
-			log.error(exc);
-			uiService.showDialog("Platform error opening source URL: " +
-				sourceLocation);
-		}
+	public Class<?> classFromSearchResult(SearchResult result) {
+		return ((ClassSearchResult) result).clazz();
 	}
 }

--- a/src/main/java/org/scijava/search/javadoc/JavadocSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/javadoc/JavadocSearchActionFactory.java
@@ -27,7 +27,7 @@
  * #L%
  */
 
-package org.scijava.search.classes;
+package org.scijava.search.javadoc;
 
 import java.io.IOException;
 import java.net.URL;
@@ -41,6 +41,7 @@ import org.scijava.search.DefaultSearchAction;
 import org.scijava.search.SearchAction;
 import org.scijava.search.SearchActionFactory;
 import org.scijava.search.SearchResult;
+import org.scijava.search.classes.ClassSearchResult;
 import org.scijava.search.javadoc.JavadocService;
 import org.scijava.ui.DialogPrompt.MessageType;
 import org.scijava.ui.UIService;

--- a/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2021 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.search.module;
+
+import org.scijava.log.LogService;
+import org.scijava.module.ModuleInfo;
+import org.scijava.platform.PlatformService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.search.DefaultSearchAction;
+import org.scijava.search.SearchAction;
+import org.scijava.search.SearchActionFactory;
+import org.scijava.search.SearchResult;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Search action for getting help on a SciJava module.
+ *
+ * @author Curtis Rueden
+ */
+@Plugin(type = SearchActionFactory.class)
+public class HelpSearchActionFactory implements SearchActionFactory {
+
+	@Parameter
+	private PlatformService platformService;
+
+	@Parameter
+	private LogService log;
+
+	@Override
+	public boolean supports(final SearchResult result) {
+		return result instanceof ModuleSearchResult;
+	}
+
+	@Override
+	public SearchAction create(final SearchResult result) {
+		return new DefaultSearchAction("Help", //
+			() -> help(((ModuleSearchResult) result)));
+	}
+
+	private void help(final ModuleSearchResult result) {
+		// HACK: For now, convert the module title into a wiki URL.
+		// In future, we need to add a url field to @Plugin for
+		// embedding the URL associated with that specific plugin.
+		final ModuleInfo info = result.info();
+		final String title = info.getTitle();
+		final String url = "https://imagej.net/" + //
+			title.replaceAll("[^a-zA-Z0-9_-]", "_");
+		try {
+			platformService.open(new URL(url));
+		}
+		catch (final IOException exc) {
+			log.error(exc);
+		}
+	}
+}

--- a/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
@@ -38,6 +38,7 @@ import org.scijava.search.DefaultSearchAction;
 import org.scijava.search.SearchAction;
 import org.scijava.search.SearchActionFactory;
 import org.scijava.search.SearchResult;
+import org.scijava.util.POM;
 
 import java.io.IOException;
 import java.net.URL;
@@ -68,18 +69,18 @@ public class HelpSearchActionFactory implements SearchActionFactory {
 	}
 
 	private void help(final ModuleSearchResult result) {
-		// HACK: For now, convert the module title into a wiki URL.
-		// In future, we need to add a url field to @Plugin for
-		// embedding the URL associated with that specific plugin.
-		final ModuleInfo info = result.info();
-		final String title = info.getTitle();
-		final String url = "https://imagej.net/" + //
-			title.replaceAll("[^a-zA-Z0-9_-]", "_");
 		try {
+			// HACK: For now, use the POM's URL
+			// In future, we need to add a url field to @Plugin for
+			// embedding the URL associated with that specific plugin.
+			final ModuleInfo info = result.info();
+			final String url = POM.getPOM(info.loadDelegateClass())
+				.getOrganizationURL();
 			platformService.open(new URL(url));
 		}
-		catch (final IOException exc) {
+		catch (final IOException | ClassNotFoundException exc) {
 			log.error(exc);
 		}
 	}
+
 }

--- a/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
@@ -1,18 +1,18 @@
 /*
  * #%L
- * ImageJ2 software for multidimensional image processing and analysis.
+ * Search framework for SciJava applications.
  * %%
- * Copyright (C) 2009 - 2021 ImageJ2 developers.
+ * Copyright (C) 2017 - 2021 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/module/HelpSearchActionFactory.java
@@ -75,7 +75,7 @@ public class HelpSearchActionFactory implements SearchActionFactory {
 			// embedding the URL associated with that specific plugin.
 			final ModuleInfo info = result.info();
 			final String url = POM.getPOM(info.loadDelegateClass())
-				.getOrganizationURL();
+				.getProjectURL();
 			platformService.open(new URL(url));
 		}
 		catch (final IOException | ClassNotFoundException exc) {

--- a/src/main/java/org/scijava/search/module/ModuleSourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/module/ModuleSourceSearchActionFactory.java
@@ -58,7 +58,7 @@ public class ModuleSourceSearchActionFactory extends SourceSearchActionFactory {
 	}
 
 	@Override
-	public Class<?> classFromSearchResult(SearchResult result) {
+	protected Class<?> classFromSearchResult(SearchResult result) {
 		try {
 			ModuleInfo info = ((ModuleSearchResult) result).info();
 			return info.loadDelegateClass();

--- a/src/main/java/org/scijava/search/module/ModuleSourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/search/module/ModuleSourceSearchActionFactory.java
@@ -1,0 +1,71 @@
+/*-
+ * #%L
+ * Search framework for SciJava applications.
+ * %%
+ * Copyright (C) 2017 - 2021 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.search.module;
+
+import org.scijava.module.ModuleInfo;
+import org.scijava.plugin.Plugin;
+import org.scijava.search.SearchActionFactory;
+import org.scijava.search.SearchResult;
+import org.scijava.search.SourceSearchActionFactory;
+
+/**
+ * Search action for viewing the source code of a Java class described by a
+ * {@link ModuleInfo}.
+ *
+ * @author Gabriel Selzer
+ */
+@Plugin(type = SearchActionFactory.class)
+public class ModuleSourceSearchActionFactory extends SourceSearchActionFactory {
+
+	@Override
+	public boolean supports(final SearchResult result) {
+		if (!(result instanceof ModuleSearchResult)) return false;
+		ModuleInfo info = ((ModuleSearchResult) result).info();
+		try {
+			info.loadDelegateClass();
+			return true;
+		}
+		catch (ClassNotFoundException exc) {
+			return false;
+		}
+	}
+
+	@Override
+	public Class<?> classFromSearchResult(SearchResult result) {
+		try {
+			ModuleInfo info = ((ModuleSearchResult) result).info();
+			return info.loadDelegateClass();
+		}
+		catch (ClassNotFoundException exc) {
+			throw new IllegalArgumentException("Cannot load class for SearchResult " +
+				result, exc);
+		}
+	}
+}

--- a/src/test/java/org/scijava/search/module/HelpSearchActionTest.java
+++ b/src/test/java/org/scijava/search/module/HelpSearchActionTest.java
@@ -113,7 +113,7 @@ public class HelpSearchActionTest {
 		action.run();
 		assertEquals(1, mockService.getOpenedURLs().size());
 		assertEquals(
-			"https://imagej.net/command_org_scijava_search_module_TestCommand",
+			"https://scijava.org/",
 			mockService.getOpenedURLs().get(0));
 
 	}

--- a/src/test/java/org/scijava/search/module/HelpSearchActionTest.java
+++ b/src/test/java/org/scijava/search/module/HelpSearchActionTest.java
@@ -1,0 +1,210 @@
+/*-
+ * #%L
+ * Search framework for SciJava applications.
+ * %%
+ * Copyright (C) 2017 - 2021 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.search.module;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.AppService;
+import org.scijava.command.CommandInfo;
+import org.scijava.module.ModuleInfo;
+import org.scijava.platform.AppEventService;
+import org.scijava.platform.Platform;
+import org.scijava.platform.PlatformService;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.search.DefaultSearchAction;
+import org.scijava.search.SearchAction;
+import org.scijava.search.SearchActionFactory;
+import org.scijava.search.SearchResult;
+
+/**
+ * Tests {@link HelpSearchActionFactory}
+ *
+ * @author Gabriel Selzer
+ */
+public class HelpSearchActionTest {
+
+	private AppService appService;
+	private SearchActionFactory factory = new HelpSearchActionFactory();
+
+	@Before
+	public void init() {
+		Context context = new Context();
+		appService = context.getService(AppService.class);
+		factory = new HelpSearchActionFactory();
+	}
+
+	@Test
+	public void testSupports() {
+		final SearchResult good = createTestResult();
+		assertTrue(factory.supports(good));
+		final SearchResult bad = new SearchResult() {
+
+			@Override
+			public String name() {
+				return null;
+			}
+
+			@Override
+			public String iconPath() {
+				return null;
+			}
+
+			@Override
+			public Map<String, String> properties() {
+				return null;
+			}
+		};
+		assertFalse(factory.supports(bad));
+	}
+
+	@Test
+	public void testCreate() {
+		final SearchResult result = createTestResult();
+		SearchAction action = factory.create(result);
+		assertTrue(action instanceof DefaultSearchAction);
+		assertEquals("Help", action.toString());
+	}
+
+	@Test
+	public void testHelp() throws NoSuchFieldException, IllegalAccessException {
+		final SearchResult result = createTestResult();
+		final MockPlatformService mockService = new MockPlatformService();
+		Field platformService = factory.getClass().getDeclaredField(
+			"platformService");
+		platformService.setAccessible(true);
+		platformService.set(factory, mockService);
+		final SearchAction action = factory.create(result);
+		action.run();
+		assertEquals(1, mockService.getOpenedURLs().size());
+		assertEquals(
+			"https://imagej.net/command_org_scijava_search_module_TestCommand",
+			mockService.getOpenedURLs().get(0));
+
+	}
+
+	private SearchResult createTestResult() {
+		ModuleInfo info = new CommandInfo(TestCommand.class);
+		return new ModuleSearchResult(info, appService.getApp().getBaseDirectory()
+			.getAbsolutePath());
+	}
+
+	private static class MockPlatformService implements PlatformService {
+
+		private final List<String> openedURLs;
+
+		public MockPlatformService() {
+			openedURLs = new ArrayList<>();
+		}
+
+		@Override
+		public List<Platform> getTargetPlatforms() {
+			return null;
+		}
+
+		@Override
+		public void open(URL url) {
+			openedURLs.add(url.toString());
+		}
+
+		public List<String> getOpenedURLs() {
+			return openedURLs;
+		}
+
+		@Override
+		public int exec(String... args) {
+			return 0;
+		}
+
+		@Override
+		public boolean registerAppMenus(Object menus) {
+			return false;
+		}
+
+		@Override
+		public AppEventService getAppEventService() {
+			return null;
+		}
+
+		@Override
+		public List<Platform> getInstances() {
+			return null;
+		}
+
+		@Override
+		public <P extends Platform> P getInstance(Class<P> pluginClass) {
+			return null;
+		}
+
+		@Override
+		public Class<Platform> getPluginType() {
+			return null;
+		}
+
+		@Override
+		public Context context() {
+			return null;
+		}
+
+		@Override
+		public Context getContext() {
+			return null;
+		}
+
+		@Override
+		public double getPriority() {
+			return 0;
+		}
+
+		@Override
+		public void setPriority(double priority) {
+
+		}
+
+		@Override
+		public PluginInfo<?> getInfo() {
+			return null;
+		}
+
+		@Override
+		public void setInfo(PluginInfo<?> info) {
+
+		}
+	}
+
+}

--- a/src/test/java/org/scijava/search/module/HelpSearchActionTest.java
+++ b/src/test/java/org/scijava/search/module/HelpSearchActionTest.java
@@ -112,10 +112,8 @@ public class HelpSearchActionTest {
 		final SearchAction action = factory.create(result);
 		action.run();
 		assertEquals(1, mockService.getOpenedURLs().size());
-		assertEquals(
-			"https://scijava.org/",
-			mockService.getOpenedURLs().get(0));
-
+		assertEquals("https://github.com/scijava/scijava-search", mockService
+			.getOpenedURLs().get(0));
 	}
 
 	private SearchResult createTestResult() {


### PR DESCRIPTION
This PR does part of the work of partitioning ImageJ Legacy's [`SourceSearchActionFactory`](https://github.com/imagej/imagej-legacy/blob/a03160552a945044a0c472ccde27d54bd76432af/src/main/java/net/imagej/legacy/search/SourceSearchActionFactory.java#L67), splitting off the section of that `SearchActionFactory` that deals with `Module`s. 

To prevent code duplication while preserving SRP, we create an `abstract` class `SourceSearchActionFactory` and rename the current `SourceSearchActionFactory` for `Class`es into `ClassSourceSearchActionFactory`. Then `ModuleSourceSearchActionFactory` was created to contain the migrated functionality.

See scijava/script-editor#63 for the other chunk of migrated functionality.