### PR TITLE
Allow only one search action per name

### DIFF
--- a/src/main/java/org/scijava/search/SearchService.java
+++ b/src/main/java/org/scijava/search/SearchService.java
@@ -29,7 +29,9 @@
 
 package org.scijava.search;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.scijava.plugin.SingletonService;
@@ -65,9 +67,13 @@ public interface SearchService extends SingletonService<SearchActionFactory>,
 	 * @return A list of actions which could possibly be executed for the result.
 	 */
 	default List<SearchAction> actions(final SearchResult result) {
+		// Create a map used to track whether a name has been seen
+		final Map<Object, Boolean> seenLabels = new HashMap<>();
 		return getInstances().stream() //
 			.filter(factory -> factory.supports(result)) //
 			.map(factory -> factory.create(result)) //
+			// NB The following line skip actions with duplicate labels
+			.filter(t -> seenLabels.putIfAbsent(t.toString(), Boolean.TRUE) == null) //
 			.collect(Collectors.toList());
 	}
 

--- a/src/test/java/org/scijava/search/module/DuplicateLabelsTest.java
+++ b/src/test/java/org/scijava/search/module/DuplicateLabelsTest.java
@@ -1,0 +1,77 @@
+
+package org.scijava.search.module;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+import org.scijava.search.DefaultSearchAction;
+import org.scijava.search.SearchAction;
+import org.scijava.search.SearchActionFactory;
+import org.scijava.search.SearchResult;
+import org.scijava.search.SearchService;
+import org.scijava.search.classes.ClassSearchResult;
+
+/**
+ * Tests that duplicate labels are removed with the {@link SearchService}
+ *
+ * @author Gabriel Selzer
+ */
+public class DuplicateLabelsTest {
+
+	/**
+	 * Used to allow the search actions to change state. Run actions can't return
+	 * anything, so we need another way to track that they run.
+	 */
+	public static Integer state = 0;
+
+	private SearchService searchService;
+
+	@Before
+	public void init() {
+		Context context = new Context();
+		searchService = context.getService(SearchService.class);
+	}
+
+	@Test
+	public void testDuplicateLabelRemoval() {
+		SearchResult dummyResult = new ClassSearchResult(this.getClass(), "");
+		List<SearchAction> actions = searchService.actions(dummyResult);
+		actions.removeIf(a -> !a.toString().equals("test"));
+		Assert.assertEquals(1, actions.size());
+		actions.get(0).run();
+		assert DuplicateLabelsTest.state == 1;
+	}
+
+	@Plugin(type = SearchActionFactory.class, priority = Priority.HIGH)
+	public static class TestSearchActionFactoryHigh implements
+		SearchActionFactory
+	{
+
+		@Override
+		public SearchAction create(SearchResult data) {
+			return new DefaultSearchAction("test", //
+				() -> DuplicateLabelsTest.state = 1 //
+			);
+		}
+	}
+
+	@Plugin(type = SearchActionFactory.class, priority = Priority.LOW)
+	public static class TestSearchActionFactoryLow implements
+		SearchActionFactory
+	{
+
+		@Override
+		public SearchAction create(SearchResult data) {
+			return new DefaultSearchAction("test", //
+				() -> DuplicateLabelsTest.state = 2 //
+			);
+		}
+
+	}
+
+}


### PR DESCRIPTION
This can remove confusion with "equivalent" search actions. With "equivalent" search actions, we mean actions of the same name.

The actions that is kept is the action coming from the highest priority SearchActionFactory.